### PR TITLE
ci(coverage): create coverage report when pull request

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,29 +1,26 @@
 name: build and test
 
 on:
-  push:
-  pull_request:
+  pull_request_target:
     branches: [master]
 
 jobs:
-  build:
+  build-and-test:
+    permissions:
+            checks: write
+            pull-requests: write
+            contents: write
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [12.x, 14.x]
-
     steps:
       - uses: actions/checkout@v3
-      - run: npm ci
-      - run: npm run build --if-present
-      - run: npm test
-        env:
-          MYSQLDB_HOST: ${{ secrets.MYSQLDB_HOST }}
-          MYSQLDB_USER: ${{ secrets.MYSQLDB_USER }}
-          MYSQLDB_PASSWORD: ${{ secrets.MYSQLDB_PASSWORD }}
-          MYSQLDB_DATABASE: ${{ secrets.MYSQLDB_DATABASE }}
-          MYSQLDB_LOCAL_PORT: ${{ secrets.MYSQLDB_LOCAL_PORT }}
-          MYSQLDB_DOCKER_PORT: ${{ secrets.MYSQLDB_DOCKER_PORT }}
-          NODE_LOCAL_PORT: ${{ secrets.NODE_LOCAL_PORT }}
-          NODE_DOCKER_PORT: ${{ secrets.NODE_DOCKER_PORT }}
+      - name: create env file and check docker build
+        run: |
+          touch .env
+          cat << EOF >> .env
+          ${{ secrets.ENV }}
+          docker-compose -f docker-compose.yml up -d --build
+          docker-compose -f "docker-compose.yml" down
+      - name : create coverage report
+        uses: ArtiomTr/jest-coverage-report-action@v2
+        with:
+          test-script: npm test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM node:16.15.1
 RUN mkdir -p /app
 WORKDIR /app
-COPY package*.json /app
+COPY package*.json /app/
 RUN npm install
-COPY . /app
+COPY . /app/
 EXPOSE 3000
 
 CMD ["npm", "run", "start:dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: '3'
 
 services:
   db:
-    build: ./database
     image: mysql:5.7
     container_name: mysql
     env_file: ./.env
@@ -11,7 +10,7 @@ services:
     ports:
       - $MYSQLDB_LOCAL_PORT:$MYSQLDB_DOCKER_PORT
     environment:
-      MYSQL_ROOT_PASSWORD: $MYSQLDB_USER
+      MYSQL_ROOT_PASSWORD: $MYSQLDB_ROOT_PASSWORD
       MYSQL_DATABASE: $MYSQLDB_DATABASE
     networks:
       - backend


### PR DESCRIPTION
## 🧑‍💻 PR 내용

build 테스트를 도커를 이용하도록 수정하였습니다.
또한 PR시 coverage report를 comment로 추가하는 github action을 추가하였습니다.

참고자료
https://docs.docker.com/language/nodejs/build-images/
https://github.com/marketplace/actions/jest-coverage-report
https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

## 📸 스크린샷
<img width="918" alt="image" src="https://user-images.githubusercontent.com/35056060/180878881-e7b61a06-4d1f-4ff3-ae57-982b054a318a.png">

PR시 다음과 같은 comment가 자동으로 추가됩니다
