### PR TITLE
ci-cd pipeline setup

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,47 @@
+name: build and deploy
+    
+on:
+  push:
+    
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/running-map:latest
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ssh connect & production
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          password: ${{ secrets.PASSWORD }}
+          port: ${{ secrets.PORT }}
+          script: |
+            cd dnd-7th-7-backend
+            docker system prune -a --volumes -f
+            docker-compose pull -q
+            docker-compose up --force-recreate --build -d --quiet-pull 2>log.out
+            cat log.out
+            

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,7 +5,30 @@ on:
     branches: [master]
 
 jobs:
-  build-and-test:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: false
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/running-map:latest
+
+  test:
+    needs: build
     permissions:
             checks: write
             pull-requests: write
@@ -13,13 +36,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: create env file and check docker build
-        run: |
-          touch .env
-          cat << EOF >> .env
-          ${{ secrets.ENV }}
-          docker-compose -f docker-compose.yml up -d --build
-          docker-compose -f "docker-compose.yml" down
       - name : create coverage report
         uses: ArtiomTr/jest-coverage-report-action@v2
         with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,16 +17,10 @@ services:
     platform: linux/x86_64
 
   web:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: $DOCKER_HUB_USER/running-map
     container_name: web
     env_file: ./.env
     restart: always
-    volumes:
-      - ./:/app
-      - /app/node_modules
-      - /app/.next
     ports:
       - $NODE_LOCAL_PORT:$NODE_DOCKER_PORT
     depends_on:

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -3,6 +3,6 @@ import { Injectable } from '@nestjs/common';
 @Injectable()
 export class AppService {
   getHello(): string {
-    return 'Hello World!';
+    return 'build-and-deploy test success';
   }
 }


### PR DESCRIPTION
## 🧑‍💻 PR 내용

 * 편리한 cd를 위해 docker-compose 파일을 바꾸었습니다. 빌드 시 도커허브에 빌드한 이미지를 올린 후 docker-compose 시 이미지를 받아옵니다.
 * 배포에는 ssh-action을 사용하였습니다. 아래와 같은 구문은 ssh-action이 docker 관련 로그를 에러가 아닌 경우에도 에러로 인식하는 문제를 막기 위하여 log를 강제로 저장해준 것 입니다. ( 관련 이슈 링크 : https://github.com/appleboy/ssh-action/issues/110 )
 ``` 
docker-compose pull -q
docker-compose up --force-recreate --build -d --quiet-pull 2>log.out
 ```
* build-and-deploy 완료 시 새로운 이미지로 동작하는 것 확인하였습니다.

참고자료 : https://velog.io/@soosungp33/CICD-%EA%B5%AC%EC%B6%95%EA%B8%B0