### PR TITLE
feat(route): add get, update, delete api

### DIFF
--- a/src/running-route/dto/update-running-route.dto.ts
+++ b/src/running-route/dto/update-running-route.dto.ts
@@ -1,0 +1,7 @@
+import { PartialType, PickType } from '@nestjs/mapped-types';
+import { CreateRunningRouteDto } from './create-running-route.dto';
+
+export class UpdateRunningRouteDto extends PickType(
+  PartialType(CreateRunningRouteDto),
+  ['review', 'recommendedTags', 'secureTags', 'files'],
+) {}

--- a/src/running-route/entities/image.entity.ts
+++ b/src/running-route/entities/image.entity.ts
@@ -21,6 +21,8 @@ export class Image {
   @CreateDateColumn()
   createdAt: Date;
 
-  @ManyToOne(() => RunningRoute, (runningRoute) => runningRoute.images)
+  @ManyToOne(() => RunningRoute, (runningRoute) => runningRoute.images, {
+    onDelete: 'CASCADE',
+  })
   runningRoute: RunningRoute;
 }

--- a/src/running-route/entities/image.entity.ts
+++ b/src/running-route/entities/image.entity.ts
@@ -15,6 +15,9 @@ export class Image {
   @Column({ type: 'varchar' })
   routeImage: string;
 
+  @Column({ type: 'varchar' })
+  key: string;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/src/running-route/entities/route-recommended-tag.entity.ts
+++ b/src/running-route/entities/route-recommended-tag.entity.ts
@@ -21,6 +21,9 @@ export class RouteRecommendedTag {
   @ManyToOne(
     () => RunningRoute,
     (runningRoute) => runningRoute.routeRecommendedTags,
+    {
+      onDelete: 'CASCADE',
+    },
   )
   runningRoute: RunningRoute;
 }

--- a/src/running-route/entities/route-secure-tag.entity.ts
+++ b/src/running-route/entities/route-secure-tag.entity.ts
@@ -18,6 +18,12 @@ export class RouteSecureTag {
   @CreateDateColumn()
   createdAt: Date;
 
-  @ManyToOne(() => RunningRoute, (runningRoute) => runningRoute.routeSecureTags)
+  @ManyToOne(
+    () => RunningRoute,
+    (runningRoute) => runningRoute.routeSecureTags,
+    {
+      onDelete: 'CASCADE',
+    },
+  )
   runningRoute: RunningRoute;
 }

--- a/src/running-route/entities/running-route.entity.ts
+++ b/src/running-route/entities/running-route.entity.ts
@@ -44,6 +44,9 @@ export class RunningRoute {
   routeImage: string;
 
   @Column({ type: 'varchar' })
+  key: string;
+
+  @Column({ type: 'varchar' })
   firstLocation: string;
 
   @Column({ type: 'varchar' })

--- a/src/running-route/running-route.controller.ts
+++ b/src/running-route/running-route.controller.ts
@@ -1,6 +1,7 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Put } from '@nestjs/common';
 import { FormDataRequest } from 'nestjs-form-data';
 import { CreateRunningRouteDto } from './dto/create-running-route.dto';
+import { UpdateRunningRouteDto } from './dto/update-running-route.dto';
 import { RunningRouteService } from './running-route.service';
 
 @Controller('running-route')
@@ -16,5 +17,14 @@ export class RunningRouteController {
   @Get('/:id')
   async getById(@Param('id') id: number) {
     return await this.runningRouteService.getById(id);
+  }
+
+  @Put('/:id')
+  @FormDataRequest()
+  async update(
+    @Param('id') id: number,
+    @Body() updateRunningRouteDto: UpdateRunningRouteDto,
+  ) {
+    return await this.runningRouteService.update(id, updateRunningRouteDto);
   }
 }

--- a/src/running-route/running-route.controller.ts
+++ b/src/running-route/running-route.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 import { FormDataRequest } from 'nestjs-form-data';
 import { CreateRunningRouteDto } from './dto/create-running-route.dto';
 import { RunningRouteService } from './running-route.service';
@@ -11,5 +11,10 @@ export class RunningRouteController {
   @FormDataRequest()
   async create(@Body() createRunningRouteDto: CreateRunningRouteDto) {
     return await this.runningRouteService.create(createRunningRouteDto);
+  }
+
+  @Get('/:id')
+  async getById(@Param('id') id: number) {
+    return await this.runningRouteService.getById(id);
   }
 }

--- a/src/running-route/running-route.controller.ts
+++ b/src/running-route/running-route.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, Param, Post, Put } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+} from '@nestjs/common';
 import { FormDataRequest } from 'nestjs-form-data';
 import { CreateRunningRouteDto } from './dto/create-running-route.dto';
 import { UpdateRunningRouteDto } from './dto/update-running-route.dto';
@@ -26,5 +34,10 @@ export class RunningRouteController {
     @Body() updateRunningRouteDto: UpdateRunningRouteDto,
   ) {
     return await this.runningRouteService.update(id, updateRunningRouteDto);
+  }
+
+  @Delete('/:id')
+  async delete(@Param('id') id: number) {
+    return await this.runningRouteService.delete(id);
   }
 }

--- a/src/running-route/running-route.service.ts
+++ b/src/running-route/running-route.service.ts
@@ -43,7 +43,7 @@ export class RunningRouteService {
     this.imageRepository = imageRepository;
   }
 
-  async uploadToAws(image: MemoryStoredFile): Promise<string> {
+  async uploadToAws(image: MemoryStoredFile): Promise<object> {
     const key = `${Date.now() + image.originalName}`;
     const params = { Bucket: process.env.AWS_S3_BUCKET_NAME, Key: key };
 
@@ -72,7 +72,12 @@ export class RunningRouteService {
         r(url.split('?')[0]);
       }),
     );
-    return imageUrl;
+
+    const result = {
+      url: imageUrl,
+      key: key,
+    };
+    return result;
   }
 
   @Transactional()
@@ -127,7 +132,8 @@ export class RunningRouteService {
           review: () => `'${review}'`,
           distance: () => `'+${distance}'`,
           runningDate: () => `'${runningDate}'`,
-          routeImage: () => `'${value}'`,
+          routeImage: () => `'${value['url']}'`,
+          key: () => `'${value['key']}'`,
           firstLocation: () => `'${firstLocation}'`,
           secondLocation: () => `'${secondLocation}'`,
           thirdLocation: () => `'${thirdLocation}'`,
@@ -161,7 +167,8 @@ export class RunningRouteService {
           files.map((file) => {
             this.uploadToAws(file).then(async (value) => {
               await this.imageRepository.save({
-                routeImage: value,
+                routeImage: value['url'],
+                key: value['key'],
                 runningRoute: routeId,
               });
             });

--- a/src/running-route/running-route.service.ts
+++ b/src/running-route/running-route.service.ts
@@ -322,4 +322,27 @@ export class RunningRouteService {
       });
     }
   }
+
+  async delete(id: number) {
+    const route = await this.runningRouteRepository.findOne({
+      where: { id: id },
+      relations: ['images'],
+    });
+
+    if (!route) {
+      throw new NotFoundException({
+        statusCode: HttpStatus.NOT_FOUND,
+        message: [`Route with ID ${id} not found`],
+        error: 'NotFound',
+      });
+    }
+
+    this.deleteImageToAws(route.key);
+
+    if (route.images !== undefined) {
+      route.images.map(async (image) => await this.deleteImageToAws(image.key));
+    }
+
+    await this.runningRouteRepository.delete(route.id);
+  }
 }


### PR DESCRIPTION
## 🧑‍💻 PR 내용
getById api 추가하였습니다.

리뷰, 추천 및 안심 태그, 등록 이미지 수정 api 추가하였습니다.
(AWS S3 이미지에 접근하기 위한 key값을 칼럼으로 추가하였습니다.)

delete api 추가하였습니다.
(경로 삭제 시 연결된 태그 및 이미지 삭제를 위해 { onDelete : CASCADE } 속성 추가하였습니다.)


## 📸 스크린샷
getById
![image](https://user-images.githubusercontent.com/89819254/183726706-9730daaf-af02-4338-acc4-d231808bc427.png)

before update
![image](https://user-images.githubusercontent.com/89819254/183727038-b81fcdf2-8fa2-4cc4-abc0-3b8b493ab9db.png)

update action
![image](https://user-images.githubusercontent.com/89819254/183727091-d183d620-71ad-496d-b596-37f1f3317bc1.png)

after update
![image](https://user-images.githubusercontent.com/89819254/183727108-f52559b0-89c8-4562-ab99-d03002b8d0a4.png)

after delete
![image](https://user-images.githubusercontent.com/89819254/183727317-e9de649d-48da-4299-9590-53634d279ac8.png)
