### PR TITLE
feat(route): search API

### DIFF
--- a/src/running-route/dto/search-query-string.dto.ts
+++ b/src/running-route/dto/search-query-string.dto.ts
@@ -1,0 +1,24 @@
+import { Transform, Type } from 'class-transformer';
+import { IsNumber, IsString } from 'class-validator';
+
+export class SearchQueryStringDto {
+  @IsNumber()
+  @Type(() => Number)
+  readonly radius: number;
+
+  @IsNumber()
+  @Type(() => Number)
+  readonly latitude: number;
+
+  @IsNumber()
+  @Type(() => Number)
+  readonly longitude: number;
+
+  @Transform(({ value }) => value.split(','))
+  @IsString({ each: true })
+  readonly recommendedTags: string[];
+
+  @Transform(({ value }) => value.split(','))
+  @IsString({ each: true })
+  readonly secureTags: string[];
+}

--- a/src/running-route/running-route.controller.ts
+++ b/src/running-route/running-route.controller.ts
@@ -6,9 +6,11 @@ import {
   Param,
   Post,
   Put,
+  Query,
 } from '@nestjs/common';
 import { FormDataRequest } from 'nestjs-form-data';
 import { CreateRunningRouteDto } from './dto/create-running-route.dto';
+import { SearchQueryStringDto } from './dto/search-query-string.dto';
 import { UpdateRunningRouteDto } from './dto/update-running-route.dto';
 import { RunningRouteService } from './running-route.service';
 
@@ -20,6 +22,11 @@ export class RunningRouteController {
   @FormDataRequest()
   async create(@Body() createRunningRouteDto: CreateRunningRouteDto) {
     return await this.runningRouteService.create(createRunningRouteDto);
+  }
+
+  @Get('/search')
+  async search(@Query() searchQueryStringDto: SearchQueryStringDto) {
+    return await this.runningRouteService.search(searchQueryStringDto);
   }
 
   @Get('/:id')


### PR DESCRIPTION
## 🧑‍💻 PR 내용
위치 정보와 태그 정보를 사용한 검색 API 추가하였습니다.

위치 정보를 통해 거리 계산 후 정해진 반경 내에 있는 경로 중 태그 정보가 하나라도 일치하는 경로를 찾는 방식으로 개발하였고
화면의 비율에 따라 반경이 달라질 것을 고려하여 radius 값도 쿼리로 함께 받았습니다.

화면에서 검색 결과가 시작점 마커로 표현되기 때문에 getById return 값에 startPoint를 추가하였습니다.

## 📸 스크린샷
![image](https://user-images.githubusercontent.com/89819254/184268421-5d3312c5-49b0-4962-ac80-623a530ae30e.png)

