### PR TITLE
feat(db): separate address to city and state

### DIFF
--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -27,7 +27,12 @@ export class CreateUserDto {
   readonly gender: string;
 
   @IsString()
-  readonly address: string;
+  @IsOptional()
+  readonly city: string;
+
+  @IsString()
+  @IsOptional()
+  readonly state: string;
 
   @IsArray()
   @IsOptional()
@@ -38,6 +43,7 @@ export class CreateUserDto {
   @IsOptional()
   @IsNumber({}, { each: true })
   readonly secureTags: number[];
+
   @IsEmail()
   readonly email: string;
 }

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -36,7 +36,10 @@ export class User {
   gender: string;
 
   @Column({ type: 'varchar', length: 50 })
-  address: string;
+  city: string;
+
+  @Column({ type: 'varchar', length: 50 })
+  state: string;
 
   @Column({ type: 'varchar', length: 30 })
   email: string;

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -70,7 +70,8 @@ describe('UserService', () => {
         password: 'test1234',
         birthDate: moment().toDate(),
         gender: 'F',
-        address: 'test address',
+        city: '서울특별시',
+        state: '성동구',
         recommendedTags: [1, 2, 4],
         secureTags: [1, 3, 5],
         email: 'test@test.com',
@@ -99,7 +100,8 @@ describe('UserService', () => {
         password: 'test1234',
         birthDate: moment().toDate(),
         gender: 'F',
-        address: 'test address',
+        city: '서울특별시',
+        state: '성동구',
         recommendedTags: [1, 2, 4],
         secureTags: [1, 3, 5],
         email: 'test@test.com',
@@ -120,7 +122,8 @@ describe('UserService', () => {
         password: 'test1234',
         birthDate: moment().toDate(),
         gender: 'A',
-        address: 'test address',
+        city: '서울특별시',
+        state: '성동구',
         recommendedTags: [1, 2, 4],
         secureTags: [1, 3, 5],
         email: 'test@test.com',
@@ -140,7 +143,8 @@ describe('UserService', () => {
         password: 'test1234',
         birthDate: moment().toDate(),
         gender: 'A',
-        address: 'test address',
+        city: '서울특별시',
+        state: '성동구',
         recommendedTags: [1, 2, 4],
         secureTags: [1, 3, 5],
         email: 'test@test.com',
@@ -156,7 +160,8 @@ describe('UserService', () => {
 
     it('update non existed user', async () => {
       const body = {
-        address: 'test address',
+        city: '서울특별시',
+        state: '성동구',
       };
 
       await expect(async () => {
@@ -172,7 +177,8 @@ describe('UserService', () => {
         password: 'test1234',
         birthDate: moment().toDate(),
         gender: 'A',
-        address: 'test address',
+        city: '서울특별시',
+        state: '성동구',
         recommendedTags: [1, 2, 4],
         secureTags: [1, 3, 5],
         email: 'test@test.com',


### PR DESCRIPTION
## 🧑‍💻 PR 내용

단일 값으로 저장되어 있던 주소를 도시와 구로 나누었습니다.
또한 주소값이 필수 정보가 아님을 추가하였습니다.

## 📸 스크린샷

<img width="689" alt="image" src="https://user-images.githubusercontent.com/35056060/184525335-3cf459b1-c890-49af-8455-f78960ea9dda.png">

