### PR TITLE
feat(route): add checkRunningExperience API

### DIFF
--- a/src/running-route/running-route.controller.ts
+++ b/src/running-route/running-route.controller.ts
@@ -7,8 +7,11 @@ import {
   Post,
   Put,
   Query,
+  Req,
+  UseGuards,
 } from '@nestjs/common';
 import { FormDataRequest } from 'nestjs-form-data';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { CreateRunningRouteDto } from './dto/create-running-route.dto';
 import { SearchQueryStringDto } from './dto/search-query-string.dto';
 import { UpdateRunningRouteDto } from './dto/update-running-route.dto';
@@ -27,6 +30,15 @@ export class RunningRouteController {
   @Get('/search')
   async search(@Query() searchQueryStringDto: SearchQueryStringDto) {
     return await this.runningRouteService.search(searchQueryStringDto);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('/checkRunningExperience/:id')
+  async checkRunningExperience(@Param('id') id: number, @Req() req) {
+    return await this.runningRouteService.checkRunningExperience(
+      id,
+      req.user.sub,
+    );
   }
 
   @Get('/:id')

--- a/src/running-route/running-route.service.ts
+++ b/src/running-route/running-route.service.ts
@@ -380,4 +380,31 @@ export class RunningRouteService {
 
     return result;
   }
+
+  async checkRunningExperience(id: number, userId: string) {
+    const route = await this.runningRouteRepository.findOneBy({
+      id: id,
+    });
+
+    if (!route) {
+      throw new ForbiddenException({
+        statusCode: HttpStatus.FORBIDDEN,
+        message: [`MainRoute with ID ${id} not exist`],
+        error: 'Forbidden',
+      });
+    }
+
+    const isExist = await this.runningRouteRepository
+      .createQueryBuilder('route')
+      .select('route.id')
+      .where('route.mainRouteId = :id', { id })
+      .andWhere('route.userUserId = :userId', { userId })
+      .execute();
+
+    if (isExist.length === 0) {
+      return { check: false };
+    } else {
+      return { check: true };
+    }
+  }
 }


### PR DESCRIPTION
## 🧑‍💻 PR 내용
따라가기를 할 경우 사용자의 이전 러닝 경험이 있는지 확인하는 API를 추가하였습니다.

## 📸 스크린샷
![image](https://user-images.githubusercontent.com/89819254/184529114-b93cedd5-5d60-45a8-a531-a9cda83ef7fc.png)

경험이 있는 경우
![image](https://user-images.githubusercontent.com/89819254/184529126-656e1398-2abd-416b-9681-07f7ddc24b8d.png)

경험이 없는 경우
![image](https://user-images.githubusercontent.com/89819254/184529136-ccbbff8b-28fb-43e0-85f6-0441b4a47475.png)
