### PR TITLE
Feat#43: separate getRoute API to main and sub

### DIFF
--- a/src/running-route/running-route.controller.ts
+++ b/src/running-route/running-route.controller.ts
@@ -41,7 +41,12 @@ export class RunningRouteController {
     );
   }
 
-  @Get('/:id')
+  @Get('/main/:id')
+  async getMainRouteDetail(@Param('id') id: number) {
+    return await this.runningRouteService.getMainRouteDetail(id);
+  }
+
+  @Get('/sub/:id')
   async getById(@Param('id') id: number) {
     return await this.runningRouteService.getById(id);
   }


### PR DESCRIPTION
## 🧑‍💻 PR 내용
mainRoute와 subRoute에 따라 상세 디테일 API를 나누었습니다.
return 값에 user에 대한 데이터도 추가하였습니다.

현재 경로 등록 API에 user 등록 부분이 없어서 
`update running_route set userUserId='test_id'` 명령 후에 실행해야 제대로 동작합니다.

## 📸 스크린샷
get mainRoute -> subRoutes에 대한 데이터가 함께 return됩니다.
![image](https://user-images.githubusercontent.com/89819254/184806777-1b8685df-3490-47a4-8c8b-bf0a4d41ced2.png)

get subRoute
![image](https://user-images.githubusercontent.com/89819254/184806806-876e7078-b003-4947-8f25-aa8426dbb4bc.png)

