### PR TITLE
feat(user): replace userId to email

### DIFF
--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -47,8 +47,4 @@ export class CreateUserDto {
   @IsOptional()
   @IsNumber({}, { each: true })
   readonly secureTags: number[];
-
-  @IsEmail()
-  @IsOptional()
-  readonly email: string;
 }

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -20,7 +20,7 @@ export class User {
   @Column({ type: 'varchar', length: 20 })
   nickname: string;
 
-  @PrimaryColumn({ type: 'varchar', length: 20 })
+  @PrimaryColumn({ type: 'varchar', length: 50 })
   userId: string;
 
   @Column({ type: 'varchar', nullable: true })
@@ -40,9 +40,6 @@ export class User {
 
   @Column({ type: 'varchar', length: 50, nullable: true })
   state: string;
-
-  @Column({ type: 'varchar', length: 30, nullable: true })
-  email: string;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -25,17 +25,19 @@ export class UserController {
     return await this.userService.create(createUserDto);
   }
 
-  @Put(':userId')
+  @UseGuards(JwtAuthGuard)
+  @Put()
   update(
-    @Param('userId') userId: string,
+    @Req() req,
     @Body() updateUserDto: UpdateUserDto,
   ): Promise<any> {
-    return this.userService.update(userId, updateUserDto);
+    return this.userService.update(req.user.userId, updateUserDto);
   }
 
-  @Delete(':id')
-  remove(@Param('id') id: string): Promise<void> {
-    return this.userService.remove(id);
+  @UseGuards(JwtAuthGuard)
+  @Delete()
+  remove(@Req() req): Promise<void> {
+    return this.userService.remove(req.user.userId);
   }
 
   @UseGuards(JwtAuthGuard)
@@ -78,5 +80,15 @@ export class UserController {
   @Get('/increaseUseRecommended')
   increaseUseRecommended(@Req() req) {
     return this.userService.increaseUseRecommended(req.user.userId);
+  }
+
+  @Get('/checkId/:id')
+  checkId(@Param('id') id: string){
+    return this.userService.checkId(id);
+  }
+
+  @Get('/checkNickname/:nickname')
+  checkNickname(@Param('nickname') nickname: string){
+    return this.userService.checkNickname(nickname);
   }
 }

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -76,15 +76,14 @@ describe('UserService', () => {
       const user = {
         name: 'test_name',
         nickname: 'test_nickname',
-        userId: 'test_id',
+        userId: 'test@test.com',
         password: 'test1234',
         birthDate: moment().toDate(),
         gender: 'F',
         city: '서울특별시',
         state: '성동구',
         recommendedTags: [1, 2, 4],
-        secureTags: [1, 3, 5],
-        email: 'test@test.com',
+        secureTags: [1, 3, 5]
       };
 
       usersRepository.save.mockResolvedValue(user);
@@ -106,15 +105,14 @@ describe('UserService', () => {
       const user = {
         name: 'test_name',
         nickname: 'test_nickname',
-        userId: 'test_id',
+        userId: 'test@test.com',
         password: 'test1234',
         birthDate: moment().toDate(),
         gender: 'F',
         city: '서울특별시',
         state: '성동구',
         recommendedTags: [1, 2, 4],
-        secureTags: [1, 3, 5],
-        email: 'test@test.com',
+        secureTags: [1, 3, 5]
       };
 
       usersRepository.findOneBy.mockResolvedValue(user);
@@ -128,15 +126,14 @@ describe('UserService', () => {
       const user = {
         name: 'test_name',
         nickname: 'test_nickname',
-        userId: 'test_id',
+        userId: 'test@test.com',
         password: 'test1234',
         birthDate: moment().toDate(),
         gender: 'A',
         city: '서울특별시',
         state: '성동구',
         recommendedTags: [1, 2, 4],
-        secureTags: [1, 3, 5],
-        email: 'test@test.com',
+        secureTags: [1, 3, 5]
       };
 
       await expect(async () => {
@@ -149,15 +146,14 @@ describe('UserService', () => {
       const before = {
         name: 'test_name',
         nickname: 'test_nickname',
-        userId: 'test_id',
+        userId: 'test@test.com',
         password: 'test1234',
         birthDate: moment().toDate(),
         gender: 'A',
         city: '서울특별시',
         state: '성동구',
         recommendedTags: [1, 2, 4],
-        secureTags: [1, 3, 5],
-        email: 'test@test.com',
+        secureTags: [1, 3, 5]
       };
 
       const after = {
@@ -183,19 +179,18 @@ describe('UserService', () => {
       const user = {
         name: 'test_name',
         nickname: 'test_nickname',
-        userId: 'test_id',
+        userId: 'test@test.com',
         password: 'test1234',
         birthDate: moment().toDate(),
         gender: 'A',
         city: '서울특별시',
         state: '성동구',
         recommendedTags: [1, 2, 4],
-        secureTags: [1, 3, 5],
-        email: 'test@test.com',
+        secureTags: [1, 3, 5]
       };
 
       const body = {
-        userId: 'new_user_id',
+        userId: 'test_new@test.com',
       };
       usersRepository.findOneBy.mockResolvedValue(user);
       await expect(async () => {

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -237,4 +237,30 @@ export class UserService {
   async increaseUseRecommended(userId: string) {
     await this.userRepository.increment({ userId: userId }, 'numberOfUse', 1);
   }
+
+  async checkId(userId: string) {
+    const isExist = await this.userRepository.findOneBy({
+      userId: userId,
+    });
+    if(isExist){
+      throw new ForbiddenException({
+        statusCode: HttpStatus.FORBIDDEN,
+        message: ['Already registered userId'],
+        error: 'Forbidden',
+      });
+    }
+  }
+
+  async checkNickname(nickname: string){
+    const isExist = await this.userRepository.findOneBy({
+      nickname: nickname,
+    });
+    if(isExist){
+      throw new ForbiddenException({
+        statusCode: HttpStatus.FORBIDDEN,
+        message: ['Already registered nickname'],
+        error: 'Forbidden',
+      });
+    }
+  }
 }


### PR DESCRIPTION
## 🧑‍💻 PR 내용

불필요한 userId attribute를 삭제하였습니다.
userId가 있는지 확인하는 api를 email을 사용하도록 하였습니다.

## 📸 스크린샷

<img width="877" alt="image" src="https://user-images.githubusercontent.com/35056060/186151833-9a72097c-47bd-4f0d-93f0-75d8057e086d.png">
