### PR TITLE
feat(route): 실시간 인기 태그 api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,5 +28,16 @@ services:
     networks:
       - backend
 
+  redis:
+    image: redis:7.0
+    container_name: redis
+    env_file: ./.env
+    restart: always
+    ports:
+      - $REDIS_LOCAL_PORT:$REDIS_DOCKER_PORT
+    command: redis-server --requirepass ${REDIS_PASSWORD}
+    networks:
+      - backend
+
 networks:
   backend:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@liaoliaots/nestjs-redis": "^8.2.2",
         "@nestjs/common": "^8.0.0",
         "@nestjs/config": "^2.2.0",
         "@nestjs/core": "^8.0.0",
@@ -22,6 +23,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.13.2",
         "codecov": "^3.8.3",
+        "ioredis": "^5.2.3",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.34",
         "mysql2": "^2.3.3",
@@ -917,6 +919,11 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1464,6 +1471,28 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@liaoliaots/nestjs-redis": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@liaoliaots/nestjs-redis/-/nestjs-redis-8.2.2.tgz",
+      "integrity": "sha512-/xBQto0ZAVjDQ7WiLuQLCy01xEtF7fiHMbffRo0dTwpC9GJ2gU1bm1VL9CbocFfAxiLDjcfIyRZuaaj3ZU6igg==",
+      "dependencies": {
+        "tslib": "2.4.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^7.0.0",
+        "@nestjs/core": "^8.0.0 || ^7.0.0",
+        "@nestjs/terminus": "^8.0.0 || ^7.0.0",
+        "ioredis": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/terminus": {
+          "optional": true
+        }
       }
     },
     "node_modules/@lukeed/csprng": {
@@ -3584,6 +3613,14 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5603,6 +5640,29 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.2.3.tgz",
+      "integrity": "sha512-gQNcMF23/NpvjCaa1b5YycUyQJ9rBNH2xP94LWinNpodMWVUPP5Ai/xXANn/SM7gfIvI62B5CCvZxhg5pOgyMw==",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.0.1",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -7346,10 +7406,20 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
@@ -8659,6 +8729,25 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
@@ -9173,6 +9262,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -11427,6 +11521,11 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -11857,6 +11956,14 @@
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "@liaoliaots/nestjs-redis": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@liaoliaots/nestjs-redis/-/nestjs-redis-8.2.2.tgz",
+      "integrity": "sha512-/xBQto0ZAVjDQ7WiLuQLCy01xEtF7fiHMbffRo0dTwpC9GJ2gU1bm1VL9CbocFfAxiLDjcfIyRZuaaj3ZU6igg==",
+      "requires": {
+        "tslib": "2.4.0"
       }
     },
     "@lukeed/csprng": {
@@ -13452,6 +13559,11 @@
         }
       }
     },
+    "cluster-key-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -14980,6 +15092,22 @@
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true
     },
+    "ioredis": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.2.3.tgz",
+      "integrity": "sha512-gQNcMF23/NpvjCaa1b5YycUyQJ9rBNH2xP94LWinNpodMWVUPP5Ai/xXANn/SM7gfIvI62B5CCvZxhg5pOgyMw==",
+      "requires": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.0.1",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      }
+    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -16283,10 +16411,20 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
     },
     "lodash.isboolean": {
       "version": "3.0.3",
@@ -17272,6 +17410,19 @@
         "resolve": "^1.1.6"
       }
     },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="
+    },
+    "redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "requires": {
+        "redis-errors": "^1.0.0"
+      }
+    },
     "reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
@@ -17657,6 +17808,11 @@
           "dev": true
         }
       }
+    },
+    "standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "statuses": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@liaoliaots/nestjs-redis": "^8.2.2",
     "@nestjs/common": "^8.0.0",
     "@nestjs/config": "^2.2.0",
     "@nestjs/core": "^8.0.0",
@@ -34,6 +35,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.13.2",
     "codecov": "^3.8.3",
+    "ioredis": "^5.2.3",
     "moment": "^2.29.4",
     "moment-timezone": "^0.5.34",
     "mysql2": "^2.3.3",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,6 +16,7 @@ import { RouteSecureTag } from './running-route/entities/route-secure-tag.entity
 import { AuthModule } from './auth/auth.module';
 import { UserRecommendedTag } from './user/entities/user-recommended-tag.entity';
 import { UserSecureTag } from './user/entities/user-secure-tag.entity';
+import { RedisModule } from '@liaoliaots/nestjs-redis';
 
 @Module({
   imports: [
@@ -47,6 +48,13 @@ import { UserSecureTag } from './user/entities/user-secure-tag.entity';
           throw new Error('Invalid options passed');
         }
         return addTransactionalDataSource(new DataSource(options));
+      },
+    }),
+    RedisModule.forRoot({
+      config: {
+        host: process.env.REDIS_HOST,
+        port: parseInt(process.env.REDIS_DOCKER_PORT),
+        password: process.env.REDIS_PASSWORD,
       },
     }),
     UserModule,

--- a/src/running-route/running-route.controller.spec.ts
+++ b/src/running-route/running-route.controller.spec.ts
@@ -8,6 +8,7 @@ import { Image } from './entities/image.entity';
 import { RouteRecommendedTag } from './entities/route-recommended-tag.entity';
 import { RouteSecureTag } from './entities/route-secure-tag.entity';
 import { DataSource } from 'typeorm';
+import { getRedisToken } from '@liaoliaots/nestjs-redis';
 
 describe('RunningRouteController', () => {
   let controller: RunningRouteController;
@@ -18,6 +19,7 @@ describe('RunningRouteController', () => {
       controllers: [RunningRouteController],
       providers: [
         RunningRouteService,
+        { provide: getRedisToken('default'), useValue: {} },
         {
           provide: DataSource,
           useValue: {},

--- a/src/running-route/running-route.controller.ts
+++ b/src/running-route/running-route.controller.ts
@@ -35,6 +35,11 @@ export class RunningRouteController {
     );
   }
 
+  @Get('/popularTags')
+  async getPopularTags() {
+    return await this.runningRouteService.getPopularTags();
+  }
+
   @Get('/searchLocation')
   async searchBasedOnLocation(
     @Query() searchQueryStringDto: LocationQueryStringDto,

--- a/src/running-route/running-route.service.spec.ts
+++ b/src/running-route/running-route.service.spec.ts
@@ -6,6 +6,7 @@ import { RunningRoute } from './entities/running-route.entity';
 import { RouteRecommendedTag } from './entities/route-recommended-tag.entity';
 import { RouteSecureTag } from './entities/route-secure-tag.entity';
 import { DataSource } from 'typeorm';
+import { getRedisToken } from '@liaoliaots/nestjs-redis';
 
 describe('RunningRouteService', () => {
   let service: RunningRouteService;
@@ -14,6 +15,7 @@ describe('RunningRouteService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RunningRouteService,
+        { provide: getRedisToken('default'), useValue: {} },
         {
           provide: DataSource,
           useValue: {},
@@ -36,7 +38,6 @@ describe('RunningRouteService', () => {
         },
       ],
     }).compile();
-
     service = module.get<RunningRouteService>(RunningRouteService);
   });
 


### PR DESCRIPTION
## 🧑‍💻 PR 내용
`docker-compose.yml`에 `redis` 관련 코드를 추가하였습니다.
등록되는 경로의 태그를 수집하여 실시간 인기태그 api를 추가하였습니다.

`.env`파일에 환경변수 추가가 필요합니다.
## 📸 스크린샷


![image](https://user-images.githubusercontent.com/89819254/189519045-c001af71-a089-4745-84fb-e8b61e8d9237.png)

docker로 띄운 redis terminal로 접속하여 확인이 가능합니다. (랭킹 6위까지 출력하는 명령입니다 👑)
```
$ redis-cli
$ auth <REDIS_PASSWORD>
$ zrevrange <REDIS_KEY> 0 6
```
![image](https://user-images.githubusercontent.com/89819254/189519027-10b45c2e-e47e-4d9e-aba7-7e0845acbb37.png)
