### PR TITLE
feat(user): add refresh token

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -12,6 +12,7 @@ import { AuthService } from './auth.service';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { KakaoAuthGuard } from './guards/kakao-auth.guard';
 import { UserKakaoDto } from 'src/user/dto/kakao-user.dto';
+import { JwtRefreshAuthGuard } from './guards/jwt-refresh-auth.guard';
 
 @Controller('auth')
 export class AuthController {
@@ -21,6 +22,12 @@ export class AuthController {
   @Post('login')
   async login(@Req() req) {
     return this.authService.login(req.user);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('logout')
+  async logout(@Req() req) {
+    return await this.authService.logout(req.user);
   }
 
   @UseGuards(JwtAuthGuard)
@@ -47,5 +54,11 @@ export class AuthController {
   @Get('/kakao/profile')
   getKakaoProfile(@Req() req) {
     return req.user;
+  }
+
+  @UseGuards(JwtRefreshAuthGuard)
+  @Get('/refresh')
+  async getToken(@Req() req) {
+    return await this.authService.refreshTokens(req.user);
   }
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -6,6 +6,7 @@ import { User } from 'src/user/entities/user.entity';
 import { UserModule } from 'src/user/user.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import { JwtRefreshStrategy } from './strategies/jwt-refresh.strategy';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { KakaoStrategy } from './strategies/kakao.strategy';
 import { LocalStrategy } from './strategies/local.strategy';
@@ -14,13 +15,16 @@ import { LocalStrategy } from './strategies/local.strategy';
   imports: [
     UserModule,
     PassportModule,
-    JwtModule.register({
-      secret: 'secret', // FIX ME
-      signOptions: { expiresIn: '3600s' },
-    }),
+    JwtModule.register({}),
     TypeOrmModule.forFeature([User]),
   ],
-  providers: [AuthService, LocalStrategy, JwtStrategy, KakaoStrategy],
+  providers: [
+    AuthService,
+    LocalStrategy,
+    JwtStrategy,
+    KakaoStrategy,
+    JwtRefreshStrategy,
+  ],
   controllers: [AuthController],
 })
 export class AuthModule {}

--- a/src/auth/guards/jwt-refresh-auth.guard.ts
+++ b/src/auth/guards/jwt-refresh-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtRefreshAuthGuard extends AuthGuard('jwt-refresh') {}

--- a/src/auth/strategies/jwt-refresh.strategy.ts
+++ b/src/auth/strategies/jwt-refresh.strategy.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { Request } from 'express';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+
+@Injectable()
+export class JwtRefreshStrategy extends PassportStrategy(
+  Strategy,
+  'jwt-refresh',
+) {
+  constructor() {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      secretOrKey: process.env.JWT_REFRESH_TOKEN_SECRET,
+      passReqToCallback: true,
+    });
+  }
+
+  validate(req: Request, payload: any) {
+    const refresh_token = req
+      ?.get('authorization')
+      ?.replace('Bearer', '')
+      .trim();
+
+    return {
+      ...payload,
+      refresh_token,
+    };
+  }
+}

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -8,7 +8,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: 'secret', // FIX ME
+      secretOrKey: process.env.JWT_ACCESS_TOKEN_SECRET,
     });
   }
 

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -1,3 +1,4 @@
+import { Exclude } from 'class-transformer';
 import {
   Entity,
   Column,
@@ -46,6 +47,10 @@ export class User {
 
   @UpdateDateColumn()
   updatedAt: Date;
+
+  @Column({ nullable: true })
+  @Exclude()
+  currentHashedRefreshToken?: string;
 
   @OneToMany(() => RunningRoute, (runningRoute) => runningRoute.user)
   runningRoutes: RunningRoute[];


### PR DESCRIPTION
## 🧑‍💻 PR 내용
access token 만료시 refresh token을 사용해 재발급 받을 수 있도록 추가하였습니다. 
refresh token은 User entity의 currentHashedRefreshToken에 저장됩니다.

+ 환경변수 추가가 필요합니다.

## 📸 스크린샷
로그인 성공 시 access token과 refresh token이 함께 발급됩니다.
![image](https://user-images.githubusercontent.com/89819254/196466625-3604258b-3c53-4a53-9dca-e7749393dc8c.png)

이전 동작과 동일하게 access token을 사용해 접근이 가능합니다.
![image](https://user-images.githubusercontent.com/89819254/196466538-e25b8ea6-8440-4bb4-b9b8-35f9a063f8d1.png)

/auth/refresh에 refresh token과 함께 요청을 보낼 경우 access token 재발급이 가능합니다.
![image](https://user-images.githubusercontent.com/89819254/196466354-f85b79fb-606d-48fc-ad69-fa7dded5900f.png)

로그아웃의 경우 DB에 저장되어 있던 refresh token을 null 값으로 변경합니다.
![image](https://user-images.githubusercontent.com/89819254/196466071-0120053a-493f-4ab3-a3bc-e278ff721f14.png)
![image](https://user-images.githubusercontent.com/89819254/196466038-0aa97421-b529-4b0c-8925-b9b97334413f.png)
