### PR TITLE
feat(user): add refresh token to kakao-login

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -20,7 +20,9 @@ export class AuthController {
 
   @UseGuards(LocalAuthGuard)
   @Post('login')
-  async login(@Req() req) {
+  async login(
+    @Req() req,
+  ): Promise<{ access_token: string; refresh_token: string }> {
     return this.authService.login(req.user);
   }
 
@@ -46,7 +48,9 @@ export class AuthController {
   @UseGuards(KakaoAuthGuard)
   @Get('/kakao/redirect')
   @HttpCode(200)
-  async kakaoLoginCallback(@Req() req): Promise<{ accessToken: string }> {
+  async kakaoLoginCallback(
+    @Req() req,
+  ): Promise<{ access_token: string; refresh_token: string }> {
     return this.authService.kakaoLogin(req.user as UserKakaoDto);
   }
 

--- a/src/auth/strategies/kakao.strategy.ts
+++ b/src/auth/strategies/kakao.strategy.ts
@@ -16,6 +16,7 @@ export class KakaoStrategy extends PassportStrategy(Strategy) {
     const payload: UserKakaoDto = {
       kakaoId: profileJson.id,
       accessToken,
+      refreshToken,
     };
     done(null, payload);
   }

--- a/src/user/dto/kakao-user.dto.ts
+++ b/src/user/dto/kakao-user.dto.ts
@@ -8,4 +8,7 @@ export class UserKakaoDto {
   @IsString()
   @IsNotEmpty()
   accessToken: string;
+
+  @IsString()
+  refreshToken: string;
 }


### PR DESCRIPTION
## 🧑‍💻 PR 내용
Kakao 로그인에 refresh token을 추가하였습니다.

## 📸 스크린샷
로그인 성공 시 access token과 refresh token이 발급됩니다.
![image](https://user-images.githubusercontent.com/89819254/196725088-b564b247-2e12-4838-a9d1-629168c02f2d.png)

access token 을 통해 profile에 접근 가능합니다.
![image](https://user-images.githubusercontent.com/89819254/196725168-2535354c-5793-42b9-b414-01a671151c0d.png)

refresh token을 통해 access token을 재발급 받을 수 있습니다.
![image](https://user-images.githubusercontent.com/89819254/196725312-49e12de7-1233-4191-b2e4-b01658457f85.png)
